### PR TITLE
Changed the deploy to enable for versioning, packing all in a zip and…

### DIFF
--- a/src/config/system.json
+++ b/src/config/system.json
@@ -8,6 +8,7 @@
         "mapimage"
     ],
     "VERSION": "0.1.0",
+    "BUILD_TYPE": "nightly",
     "ENVIRONMENT": "production",
     "NAME_INPUT_DEBOUNCE_TIME_MS": 100,
     "KEY": "O5g51hWHqFFyLI-w2YrB-puJ91t9XGTiyumit01RC88="

--- a/src/main.py
+++ b/src/main.py
@@ -466,7 +466,14 @@ class WorldBuildingApp(QMainWindow):
             self.setCentralWidget(self.components.ui)
 
             # Set window title with version
-            self.setWindowTitle(f"NeoWorldBuilder {self.components.config.VERSION}")
+            version = self.components.config.VERSION
+            build_type = self.components.config.BUILD_TYPE
+
+            # Show version with build type if not release
+            if build_type == "release":
+                self.setWindowTitle(f"NeoWorldBuilder {version}")
+            else:
+                self.setWindowTitle(f"NeoWorldBuilder {version}-{build_type}")
 
             # Ensure transparency is properly set
             self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, False)


### PR DESCRIPTION
… including a small readme.txt for install instructions.

## Summary by Sourcery

Add versioning and packaging to the deployment process. Create a distribution zip file containing the application and its required files. Include a README.txt file with installation instructions in the zip file. Display the build type in the application title for non-release builds.

Enhancements:
- Determine build type from command-line arguments, environment variables, or the config file.

Build:
- Package the application into a zip file named "NeoWorldBuilder-{version}-{build_type}.zip".
- Generate a "README.txt" file containing setup and usage instructions.

Deployment:
- Enable versioning for deployments.