### PR TITLE
Rename feature

### DIFF
--- a/Writerside/topics/changelog.md
+++ b/Writerside/topics/changelog.md
@@ -1,0 +1,5 @@
+Changelog
+=========
+0.2.0
+
+- Added rename feature for node names

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -932,12 +932,16 @@ class WorldBuildingUI(QWidget):
         if not self.controller.current_node_element_id:
             return
 
-        menu = QMenu()
-        rename_action = menu.addAction("Rename Node")
-        action = menu.exec(self.name_input.mapToGlobal(position))
+        # Create standard context menu with default actions
+        menu = self.name_input.createStandardContextMenu()
 
-        if action == rename_action:
-            self.show_rename_dialog()
+        # Add rename option if we have a node loaded
+        if self.controller.current_node_element_id:
+            menu.addSeparator()
+            rename_action = menu.addAction("Rename Node")
+            rename_action.triggered.connect(self.show_rename_dialog)
+
+        menu.exec(self.name_input.mapToGlobal(position))
 
     def show_rename_dialog(self) -> None:
         """Show dialog for renaming node."""


### PR DESCRIPTION
Added the ability to rename nodes. Before the name was the unique identifier of the node, making it change required accessing the neo4j element_id. Straightforward from there.

## Summary by Sourcery

Add the ability to rename nodes in the graph.

New Features:
- Introduce node renaming functionality through a context menu option in the name input field.

Tests:
- Added integration tests to verify node renaming functionality.